### PR TITLE
fix the git tag error and change some configuration

### DIFF
--- a/dsl/nightly.dsl
+++ b/dsl/nightly.dsl
@@ -19,7 +19,14 @@ pipelineJob('nightly_intel_testbed') {
     definition {
         cpsScm {
             scm {
-                git(gitUrl)
+                    git {
+                    remote {
+                        url(gitUrl)
+                        name("origin")
+                    }
+                    branch("*/master")
+                    extensions { }
+                }
             }
             scriptPath("./pipeline/intel_testbed.jenkinsfile")
         }

--- a/dsl/smoke.dsl
+++ b/dsl/smoke.dsl
@@ -19,7 +19,14 @@ pipelineJob('smoke_intel_testbed') {
     definition {
         cpsScm {
             scm {
-                git(ciUrl)
+                git {
+                    remote {
+                        url(vrouterUrl)
+                        name("origin")
+                    }
+                    branch("*/R5.0")
+                    extensions { }
+                }
             }
             scriptPath("./pipeline/intel_testbed.jenkinsfile")
         }

--- a/dsl/weekly.dsl
+++ b/dsl/weekly.dsl
@@ -20,7 +20,14 @@ pipelineJob('weekly_intel_testbed') {
     definition {
         cpsScm {
             scm {
-                git(ciUrl)
+                git {
+                    remote {
+                        url(vrouterUrl)
+                        name("origin")
+                    }
+                    branch("*/R5.0")
+                    extensions { }
+                }
             }
             scriptPath("./pipeline/intel_testbed.jenkinsfile")
         }

--- a/dsl/weekly.dsl
+++ b/dsl/weekly.dsl
@@ -22,10 +22,10 @@ pipelineJob('weekly_intel_testbed') {
             scm {
                 git {
                     remote {
-                        url(vrouterUrl)
+                        url(ciUrl)
                         name("origin")
                     }
-                    branch("*/R5.0")
+                    branch("*/master")
                     extensions { }
                 }
             }


### PR DESCRIPTION
Two things that I have modified. 
 
One is about the pipelineJob configuration. Using the default configuration of the pipelineJob definition, the Job will make a git tag for every build which we don't need. Because we didn't make any configuration for the git tag step, it will cause error when the pipelineJob runs. Now, I config it in the dsl so it will not run the git tag step for every build. 

The other one is that I changed the smoke.dsl and weekly.dsl to monitor the vrouter repo instead of the ci repo.